### PR TITLE
muxer edits to go with healpix ingestion

### DIFF
--- a/ampel/ztf/ingest/ZiArchiveMuxer.py
+++ b/ampel/ztf/ingest/ZiArchiveMuxer.py
@@ -36,7 +36,12 @@ class ZiArchiveMuxer(AbsT0Muxer):
 
     #: Number of days of history to add, relative to the earliest point in the
     #: t0 collection
-    history_days: int
+    history_days: float = 0
+    #: Number of days of looking ahead based on the JD contained in alert
+    #: Only effect if original alert obtained through time-dependent search
+    #:Warning: could interfer if further alserts added ex through ZiMongoMuxer
+    future_days: float = 0
+
 
     shaper: Union[UnitModel, str] = "ZiDataPointShaper"
     archive_token: NamedSecret[str] = NamedSecret(label="ztf/archive/token")
@@ -118,19 +123,40 @@ class ZiArchiveMuxer(AbsT0Muxer):
         else:
             return min((from_alert, from_db))
 
+    def get_latest_jd(
+        self, datapoints: Sequence[DataPoint]
+    ) -> float:
+        """
+        return the largest jd of any photopoint in datapoints
+        Note: Not checking the DB - thought the window should be rel to alert?
+        """
+        return max(
+            (
+                dp["body"]["jd"]
+                for dp in datapoints
+                if dp["id"] > 0 and "ZTF" in dp["tag"]
+            )
+        )
+
+
     @backoff.on_exception(
         backoff.expo,
         requests.HTTPError,
         giveup=lambda e: e.response.status_code not in {503, 504, 429, 408},
         max_time=600,
     )
-    def get_photopoints(self, ztf_name: str, before_jd: float) -> list[dict[str, Any]]:
+    def get_photopoints(self, ztf_name: str, jd_center: float, time_pre: float, time_post: float) -> dict[str, Any]:
         response = self.session.get(
             f"object/{ztf_name}/photopoints",
-            params={"jd_end": before_jd, "jd_start": before_jd - self.history_days},
+            params={
+                "jd_end": jd_center+time_post,
+                "jd_start": jd_center-time_pre,
+                },
         )
         response.raise_for_status()
         return response.json()
+
+
 
     def process(
         self, dps: List[DataPoint], stock_id: Optional[StockId] = None
@@ -141,19 +167,44 @@ class ZiArchiveMuxer(AbsT0Muxer):
         Attempt to determine which pps/uls should be inserted into the t0 collection,
         and which one should be marked as superseded.
         """
-        # Find photopoints from earlier alerts
-        if stock_id is None or not (
-            history := self.get_photopoints(
-                to_ztf_id(stock_id),
-                before_jd=self.get_earliest_jd(to_ztf_id(stock_id), dps),
-            )
-        ):
+
+        if not stock_id:
             # no new points to add; use input points for combination
             return dps, dps
 
-        alert = ZiAlertSupplier.shape_alert_dict(history)
-        dps_to_insert = self._shaper.process(alert.datapoints, stock_id)
+        # Alert jd, assumed to be latest dp
+        alert_jd =  max(
+            (
+                dp["body"]["jd"]
+                for dp in dps
+                if dp["id"] > 0 and "ZTF" in dp["tag"]
+            )
+        )
 
-        extended_dps = sorted(dps_to_insert + dps, key=lambda d: d["body"]["jd"])
+        # Obtain archive alert based on this
+        # - _possibly_ inefficient since we also search within alert time range
+        archive_alert_dict = self.get_photopoints(
+            to_ztf_id(stock_id), alert_jd, self.history_days, self.future_days
+             )
+        archive_alert = ZiAlertSupplier.shape_alert_dict(archive_alert_dict)
+        archive_dps = self._shaper.process(archive_alert.datapoints, stock_id)
+        if len(archive_dps)==0:
+            # nothing found in archive
+            return dps, dps
+
+
+        # Create combined state of alert and archive
+        # Only dps with a new jd are added. In practice this means that
+        # if (for some reason) a detection exists in the archive, but
+        # an upper limit is provided in the alert, then the upper limit is used.
+        jds_alert = [dp['body']['jd'] for dp in dps]
+        extended_dps = sorted(
+            dps + [dp for dp in archive_dps if not dp['body']['jd'] in jds_alert],
+            key=lambda d: d["body"]["jd"])
+
+        # Potentially one could here check the DB content, both to extend
+        # the state and avoid duplicate inserts. Would then also need to
+        # check for superseeded dps.
+        # There is possibly an advantage of having a "pure" archive state.
 
         return extended_dps, extended_dps

--- a/tests/test_muxers.py
+++ b/tests/test_muxers.py
@@ -264,8 +264,11 @@ def test_get_photopoints_from_api(mock_context, archive_token):
     muxer = _make_muxer(
         mock_context, UnitModel(unit="ZiArchiveMuxer", config={"history_days": 30})
     )
-    alert = muxer.get_photopoints("ZTF18abcfcoo", before_jd=2458300)
-    assert len(alert["prv_candidates"]) == 10
+    alert_pre = muxer.get_photopoints("ZTF18abcfcoo", jd_center=2458300, time_pre=30, time_post=0)
+
+    alert_post = muxer.get_photopoints("ZTF18abcfcoo", jd_center=2458270, time_pre=0, time_post=30)
+
+    assert len(alert_pre["prv_candidates"]) == 10 and len(alert_post["prv_candidates"]) == 10
 
 
 def test_deduplication(


### PR DESCRIPTION
Added option to also look into "the future" based on reference time.

Main functional change is that previously the length of the history query was made relative to the earliest detection in the processed alert history or in the alert DB, while it is now determined based on the actual time of the alert. Since there is no way to know how long the history of an accepted alert is, the previous behavior caused a lot of unpredictable behavior.
An inefficiency in this setup is that an archive query might return datapoints which are already in the DB. At the other hand, we would not have to call the db to check hat exist.

The method get_earliest_jd still exists, but is not used in the main process method.